### PR TITLE
fix: Bump service-base to 1.3.1, model to 1.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ import scala.util.Properties.envOrElse
 
 name := "mtb-query-service"
 ThisBuild / organization := "de.dnpm.dip"
-ThisBuild / scalaVersion := "2.13.16"
-ThisBuild / version      := envOrElse("VERSION","1.1.1")
+ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / version      := envOrElse("VERSION","1.1.3-SNAPSHOT")
 
 val ownerRepo  = envOrElse("REPOSITORY","dnpm-dip/mtb-query-service").split("/")
 ThisBuild / githubOwner      := ownerRepo(0)
@@ -68,16 +68,16 @@ lazy val impl = project
 lazy val dependencies =
   new {
     val scalatest      = "org.scalatest"  %% "scalatest"              % "3.2.17" % Test
-    val mtb_model      = "de.dnpm.dip"    %% "mtb-dto-model"          % "1.1.2"
-    val mtb_generators = "de.dnpm.dip"    %% "mtb-dto-generators"     % "1.1.2"
-    val service_base   = "de.dnpm.dip"    %% "service-base"           % "1.2.1"
-    val connector_base = "de.dnpm.dip"    %% "connector-base"         % "1.1.1"
-    val icd10gm        = "de.dnpm.dip"    %% "icd10gm-impl"           % "1.1.2" % Test
-    val icdo3          = "de.dnpm.dip"    %% "icdo3-impl"             % "1.1.2" % Test
-    val icd_catalogs   = "de.dnpm.dip"    %% "icd-claml-packaged"     % "1.1.2" % Test
-    val atc_impl       = "de.dnpm.dip"    %% "atc-impl"               % "1.1.0" % Test
-    val atc_catalogs   = "de.dnpm.dip"    %% "atc-catalogs-packaged"  % "1.1.0" % Test
-    val hgnc_geneset   = "de.dnpm.dip"    %% "hgnc-gene-set-impl"     % "1.1.0" % Test
+    val service_base   = "de.dnpm.dip"    %% "service-base"           % "1.3.1"
+    val mtb_model      = "de.dnpm.dip"    %% "mtb-dto-model"          % "1.2.1"
+    val mtb_generators = "de.dnpm.dip"    %% "mtb-dto-generators"     % "1.2.1"
+    val connector_base = "de.dnpm.dip"    %% "connector-base"         % "1.1.2"
+    val icd10gm        = "de.dnpm.dip"    %% "icd10gm-impl"           % "1.1.3" % Test
+    val icdo3          = "de.dnpm.dip"    %% "icdo3-impl"             % "1.1.3" % Test
+    val icd_catalogs   = "de.dnpm.dip"    %% "icd-claml-packaged"     % "1.1.3" % Test
+    val atc_impl       = "de.dnpm.dip"    %% "atc-impl"               % "1.1.1" % Test
+    val atc_catalogs   = "de.dnpm.dip"    %% "atc-catalogs-packaged"  % "1.1.1" % Test
+    val hgnc_geneset   = "de.dnpm.dip"    %% "hgnc-gene-set-impl"     % "1.1.2" % Test
   }
 
 

--- a/impl/src/main/scala/de/dnpm/dip/mtb/query/impl/KaplanMeier.scala
+++ b/impl/src/main/scala/de/dnpm/dip/mtb/query/impl/KaplanMeier.scala
@@ -214,7 +214,7 @@ extends KaplanMeierModule[cats.Id]
     
       record
         .patient
-        .dateOfDeath.map(_.atEndOfMonth)
+        .dateOfDeath
         .map(_ -> true)
         .getOrElse(
           // 1. Censoring time strategy: fall back to date of last therapy follow-up
@@ -254,7 +254,7 @@ extends KaplanMeierModule[cats.Id]
           }
       )
       // 3. Use patient date of death as "progression" date
-      .orElse(patient.dateOfDeath.map(_.atEndOfMonth))
+      .orElse(patient.dateOfDeath)
       .map(_ -> true)
       // 4. Censoring: therapy recording date
       .getOrElse(therapy.recordedOn -> false)

--- a/impl/src/main/scala/de/dnpm/dip/mtb/query/impl/MTBQueryServiceImpl.scala
+++ b/impl/src/main/scala/de/dnpm/dip/mtb/query/impl/MTBQueryServiceImpl.scala
@@ -1,6 +1,7 @@
 package de.dnpm.dip.mtb.query.impl 
 
 
+import scala.util.Properties.envOrNone
 import scala.concurrent.Future
 import cats.{
   Id,
@@ -19,7 +20,7 @@ import de.dnpm.dip.service.query.{
   Query,
   QueryCache,
   BaseQueryCache,
-  PeerToPeerQuery,
+  FederatedQuery,
   PatientRecordRequest,
   LocalDB,
   PreparedQueryDB
@@ -53,6 +54,11 @@ object MTBQueryServiceImpl extends Logging
   private val cache =
     new BaseQueryCache[MTBQueryCriteria,MTBResultSet,MTBPatientRecord]
 
+  private val federatedQueriesActive =
+    envOrNone("ACTIVE_FEDERATED_QUERY_USE_CASES")
+      .map(_.split(",").map(_.trim.toUpperCase).toSet)
+      .exists(_ contains "MTB")
+
 
   private lazy val connector =
     System.getProperty(HttpConnector.Type.property,"broker") match {
@@ -61,20 +67,16 @@ object MTBQueryServiceImpl extends Logging
         HttpConnector(
           typ,
           { 
-            case _: PeerToPeerQuery[_,_] =>
+            case _: FederatedQuery[_,_] =>
               (POST, s"$baseURI/query", Map.empty)
 
-            case req: PatientRecordRequest[_] =>
-              val params =
-                Map(
-                  "querier" -> Seq(req.querier.value),
-                  "patient" -> Seq(req.patient.value)
-                ) ++ req.snapshot.map(
-                  snp => "snapshot" -> Seq(snp.toString)
-                )
-
-              (GET, s"$baseURI/patient-record", params)
-//              (POST, s"$baseURI/patient-record", Map.empty)
+            case PatientRecordRequest(_,querier,patient,snapshot) =>
+              (
+                GET, s"$baseURI/patient-record", Map(
+                  "querier" -> Seq(querier.value),
+                  "patient" -> Seq(patient.value)
+                ) ++ snapshot.map(snp => "snapshot" -> Seq(snp.toString))
+              )
           }        
         )
 
@@ -89,7 +91,8 @@ object MTBQueryServiceImpl extends Logging
       MTBPreparedQueryDB.instance,      
       MTBLocalDB.instance,
       connector,
-      cache
+      cache,
+      federatedQueriesActive
     )
 }
 
@@ -99,7 +102,8 @@ class MTBQueryServiceImpl
   val preparedQueryDB: PreparedQueryDB[Future,Monad[Future],MTBQueryCriteria,String],
   val db: LocalDB[Future,Monad[Future],MTBQueryCriteria,MTBPatientRecord],
   val connector: Connector[Future,Monad[Future]],
-  val cache: QueryCache[MTBQueryCriteria,MTBResultSet,MTBPatientRecord]
+  val cache: QueryCache[MTBQueryCriteria,MTBResultSet,MTBPatientRecord],
+  val federatedQueriesActive: Boolean
 )
 extends BaseQueryService[Future,MTBConfig]
 with MTBQueryService

--- a/impl/src/main/scala/de/dnpm/dip/mtb/query/impl/MTBQueryServiceImpl.scala
+++ b/impl/src/main/scala/de/dnpm/dip/mtb/query/impl/MTBQueryServiceImpl.scala
@@ -1,7 +1,6 @@
 package de.dnpm.dip.mtb.query.impl 
 
 
-import scala.util.Properties.envOrNone
 import scala.concurrent.Future
 import cats.{
   Id,
@@ -55,7 +54,7 @@ object MTBQueryServiceImpl extends Logging
     new BaseQueryCache[MTBQueryCriteria,MTBResultSet,MTBPatientRecord]
 
   private val federatedQueriesActive =
-    envOrNone("ACTIVE_FEDERATED_QUERY_USE_CASES")
+    sys.env.get("ACTIVE_FEDERATED_QUERY_USE_CASES")
       .map(_.split(",").map(_.trim.toUpperCase).toSet)
       .exists(_ contains "MTB")
 

--- a/impl/src/test/scala/de/dnpm/dip/mtb/query/impl/Tests.scala
+++ b/impl/src/test/scala/de/dnpm/dip/mtb/query/impl/Tests.scala
@@ -34,7 +34,7 @@ class Tests extends AsyncFlatSpec
   import de.dnpm.dip.util.Completer.syntax._
   import de.dnpm.dip.mtb.gens.Generators._
 
-  System.setProperty(Site.property,"UKx:Musterlingen")
+  System.setProperty(Site.PROP,"UKx:Musterlingen")
   System.setProperty(HttpConnector.Type.property,"fake")
   System.setProperty(MTBLocalDB.dataGenProp,"0")
 
@@ -89,18 +89,7 @@ class Tests extends AsyncFlatSpec
             )
           )
           .toSet
-/*
-      cnv = 
-        ngs.results
-          .copyNumberVariants
-          .head
 
-      cnvCriteria =
-        CNVCriteria(
-          Some(cnv.reportedAffectedGenes.getOrElse(Set.empty).take(1)),
-          Some(cnv.`type`)
-        )
-*/
       medicationCriteria =
         patRec
           .getSystemicTherapies
@@ -137,17 +126,6 @@ class Tests extends AsyncFlatSpec
         )
       ),
       None,
-/*      
-      Some(
-        VariantCriteria(
-          Some(LogicalOperator.Or),
-          Some(snvCriteria),
-          Some(Set(cnvCriteria)),
-          None,
-          None
-        )
-      ),
-*/    
       medicationCriteria,
       None
     )
@@ -205,28 +183,22 @@ class Tests extends AsyncFlatSpec
 
       query = result.value
 
-      queryCriteria =
-        query.criteria.value
+      queryCriteria = query.criteria.value
 
-      resultSet <-
-        service.resultSet(query.id)
-          .map(_.value)
+      resultSet <- service.resultSet(query.id).map(_.value)
 
-      patientMatches = 
-        resultSet.patientMatches(MTBFilters.empty)
+      patientMatches = resultSet.patientMatches(MTBFilters.empty)
 
       _ = patientMatches must not be empty
 
       _ = patientMatches.size must be < (dataSets.size) 
 
-      matchingCriteria =
-        patientMatches.map(_.matchingCriteria)
+      matchingCriteria = patientMatches.map(_.matchingCriteria)
 
       _ = all (matchingCriteria) must be (defined)
 
     } yield forAll(matchingCriteria){ 
-      matches =>
-        assert( (queryCriteria intersect matches.value).nonEmpty )
+      matches => assert( (queryCriteria intersect matches.value).nonEmpty )
     }
 
   }
@@ -244,19 +216,15 @@ class Tests extends AsyncFlatSpec
 
       query = result.value
 
-      resultSet <-
-        service.resultSet(query.id)
-          .map(_.value)
+      resultSet <- service.resultSet(query.id).map(_.value)
 
-      filter =
-        MTBFilters.empty
-          .copy(
-            patient = PatientFilter.empty.copy(
-              gender = Some(Set(Coding(Gender.Female)))
-            )
-          )
-      patientMatches = 
-        resultSet.patientMatches(filter)
+      filter = MTBFilters.empty.copy(
+        patient = PatientFilter.empty.copy(
+          gender = Some(Set(Coding(Gender.Female)))
+        )
+      )
+
+      patientMatches = resultSet.patientMatches(filter)
 
     } yield patientMatches.size must be < (dataSets.size)
 
@@ -266,8 +234,7 @@ class Tests extends AsyncFlatSpec
   "PreparedQuery" must "have been successfully created" in {
 
     for {
-      result <-
-        service ! PreparedQuery.Create("Dummy Prepared Query",genCriteria.next)
+      result <- service ! PreparedQuery.Create("Dummy Prepared Query",genCriteria.next)
 
     } yield result.isRight mustBe true 
 
@@ -276,13 +243,11 @@ class Tests extends AsyncFlatSpec
   it must "have been successfully retrieved" in {
 
     for {
-      result <-
-        service ? PreparedQuery.Filter(Some(querier))
+      result <- service ? PreparedQuery.Filter(Some(querier))
 
       _ = result must not be empty 
 
-      query <- 
-        service ? result.head.id
+      query <- service ? result.head.id
 
     } yield query must be (defined)
 


### PR DESCRIPTION
fix: Bump service-base to 1.3.1, model to 1.2.1 and code-system dependencies in tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added federated query support configurable via environment variables.

* **Bug Fixes**
  * Corrected date handling in Kaplan-Meier survival analysis to use exact death dates instead of rounded dates.

* **Chores**
  * Updated Scala version and project dependencies.
  * Bumped project version to 1.1.3.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnpm-dip/mtb-query-service/pull/7)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->